### PR TITLE
Fix line edit offsetting in dynamic sized spinbox on startup bug

### DIFF
--- a/WAT-Mono.csproj.old.2
+++ b/WAT-Mono.csproj.old.2
@@ -1,4 +1,4 @@
-<Project Sdk="Godot.NET.Sdk/3.3.0">
+<Project Sdk="Godot.NET.Sdk/3.2.3">
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
     <RootNamespace>WATMono</RootNamespace>

--- a/addons/WAT/ui/scripts/dynamic_size_spinbox.gd
+++ b/addons/WAT/ui/scripts/dynamic_size_spinbox.gd
@@ -9,6 +9,10 @@ func _ready():
 	get_line_edit().connect("focus_exited", self, "_on_focus_exited")
 	connect("value_changed", self, "_on_value_changed")
 	oldText = get_line_edit().text
+	
+	# Set's the text to itself in order to shoot an update to the line edit
+	# This is needed or else the line edit starts off off-centered at startup
+	get_line_edit().text = oldText
 
 func _on_focus_exited():
 	# Disgusting frame waiting workaround because there is currently no way to 

--- a/project.godot
+++ b/project.godot
@@ -52,7 +52,7 @@ config/icon="res://icon.png"
 
 [editor_plugins]
 
-enabled=PoolStringArray( "WAT" )
+enabled=PoolStringArray( "res://addons/WAT/plugin.cfg" )
 
 [rendering]
 


### PR DESCRIPTION
Fixes this weird offset bug that occurs on startup. It seems like it occurs due to the line edit of the spin box not updating when it enters the tree, so I forced an update by setting its text to its original text.

![WeirdUIBug](https://user-images.githubusercontent.com/25368491/117516811-2a88cc80-af68-11eb-8149-eb0009b2d073.PNG)

The WAT GD-Script PR for dynamically-sized spinboxes already has this update included in it, so you don't have to worry about updating that repo.