### PR TITLE
Add support for rescaling icons dynamically for HiDPI users.

### DIFF
--- a/addons/WAT/gui.tscn
+++ b/addons/WAT/gui.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=3 format=2]
 
-[ext_resource path="res://addons/WAT/ui/scripts/GUI.gd" type="Script" id=1]
+[ext_resource path="res://addons/WAT/ui/scripts/gui.gd" type="Script" id=1]
 [ext_resource path="res://addons/WAT/ui/scenes/Core.tscn" type="PackedScene" id=3]
 
 [node name="Tests" type="PanelContainer"]

--- a/addons/WAT/plugin.gd
+++ b/addons/WAT/plugin.gd
@@ -7,9 +7,17 @@ const Title: String = "Tests"
 const Settings: Script = preload("res://addons/WAT/settings.gd")
 const GUI: PackedScene = preload("res://addons/WAT/gui.tscn")
 const Docker: Script = preload("res://addons/WAT/ui/scripts/docker.gd")
+const PluginAssetsRegistry: Script = preload("res://addons/WAT/ui/scripts/plugin_assets_registry.gd")
 var instance: Control
 var docker: Docker
 var script_editor: ScriptEditor
+var assets_registry = PluginAssetsRegistry.new(self)
+
+func _ready():
+	# Editor assets must be setup at ready time to give GUI scripts a chance to 
+	# ready themselves first and store references to other nodes, which will be 
+	# needed to call_setup_editor_assets() on.
+	instance._setup_editor_assets(assets_registry)
 
 func _enter_tree():
 	Settings.initialize()
@@ -81,7 +89,6 @@ func observe_filesystem(filesystem, menu: Button) -> void:
 	if not filesystem.is_connected("file_removed", menu, "_on_file_removed"):
 		filesystem.connect("file_removed", menu, "_on_file_removed")
 	
-
 func stop_observing_filesystem(filesystem, menu: Button) -> void:
 	if filesystem.is_connected("folder_moved", menu, "_on_folder_moved"):
 		filesystem.disconnect("folder_moved", menu, "_on_folder_moved")

--- a/addons/WAT/ui/scenes/Core.tscn
+++ b/addons/WAT/ui/scenes/Core.tscn
@@ -18,7 +18,7 @@ __meta__ = {
 }
 
 [node name="Menu" parent="." instance=ExtResource( 3 )]
-margin_right = 791.0
+margin_right = 766.0
 size_flags_horizontal = 0
 size_flags_vertical = 0
 

--- a/addons/WAT/ui/scenes/Menu.tscn
+++ b/addons/WAT/ui/scenes/Menu.tscn
@@ -1,10 +1,11 @@
-[gd_scene load_steps=13 format=2]
+[gd_scene load_steps=14 format=2]
 
 [ext_resource path="res://addons/WAT/ui/scripts/links.gd" type="Script" id=1]
 [ext_resource path="res://addons/WAT/assets/play.png" type="Texture" id=2]
 [ext_resource path="res://addons/WAT/ui/scenes/TestMenu.tscn" type="PackedScene" id=3]
 [ext_resource path="res://addons/WAT/ui/scenes/RunSettings.tscn" type="PackedScene" id=4]
 [ext_resource path="res://addons/WAT/ui/scripts/save_metadata.gd" type="Script" id=5]
+[ext_resource path="res://addons/WAT/ui/scripts/menu.gd" type="Script" id=6]
 
 [sub_resource type="StyleBoxEmpty" id=1]
 
@@ -25,15 +26,16 @@ shortcut = SubResource( 6 )
 margin_right = 1004.0
 margin_bottom = 24.0
 size_flags_horizontal = 3
+script = ExtResource( 6 )
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
 [node name="QuickRunAll" type="Button" parent="."]
 margin_right = 16.0
-margin_bottom = 16.0
+margin_bottom = 24.0
 size_flags_horizontal = 0
-size_flags_vertical = 0
+size_flags_vertical = 5
 custom_styles/hover = SubResource( 1 )
 custom_styles/pressed = SubResource( 2 )
 custom_styles/focus = SubResource( 3 )
@@ -46,40 +48,40 @@ flat = true
 [node name="TestMenu" parent="." instance=ExtResource( 3 )]
 margin_left = 20.0
 margin_right = 102.0
-margin_bottom = 20.0
 size_flags_horizontal = 0
-size_flags_vertical = 0
+size_flags_vertical = 5
 
 [node name="ResultsMenu" type="MenuButton" parent="."]
 margin_left = 106.0
 margin_right = 202.0
-margin_bottom = 20.0
+margin_bottom = 24.0
 size_flags_horizontal = 0
-size_flags_vertical = 0
+size_flags_vertical = 5
 text = "Filter Results"
 items = [ "Expand All", null, 0, false, false, 0, 0, null, "", false, "Collapse All", null, 0, false, false, 1, 0, null, "", false, "Expand All Failures", null, 0, false, false, 2, 0, null, "", false ]
 
 [node name="RunSettings" parent="." instance=ExtResource( 4 )]
 margin_left = 206.0
-margin_right = 634.0
+margin_right = 609.0
 size_flags_horizontal = 0
-size_flags_vertical = 0
+size_flags_vertical = 5
 
 [node name="SaveMetadata" type="Button" parent="."]
-margin_left = 638.0
-margin_right = 742.0
+margin_left = 613.0
+margin_right = 717.0
 margin_bottom = 24.0
 hint_tooltip = "Save metadata before uploading to source control if you use continous integration."
+size_flags_vertical = 5
 text = "Save Metadata"
 flat = true
 script = ExtResource( 5 )
 
 [node name="Links" type="MenuButton" parent="."]
-margin_left = 746.0
-margin_right = 791.0
-margin_bottom = 20.0
+margin_left = 721.0
+margin_right = 766.0
+margin_bottom = 24.0
 size_flags_horizontal = 0
-size_flags_vertical = 0
+size_flags_vertical = 5
 text = "Links"
 items = [ "Support WAT", null, 0, false, false, 0, 0, "https://ko-fi.com/alexanddraw", "", false, "Report An Issue", null, 0, false, false, 1, 0, "https://github.com/CodeDarigan/WAT-GDScript/issues/new", "", false, "Request Docs", null, 0, false, false, 2, 0, "https://github.com/CodeDarigan/WAT-Documentation/issues/new", "", false, "Online Docs", null, 0, false, false, 3, 0, "https://wat.readthedocs.io/en/latest/", "", false ]
 script = ExtResource( 1 )

--- a/addons/WAT/ui/scripts/core.gd
+++ b/addons/WAT/ui/scripts/core.gd
@@ -38,3 +38,4 @@ func _repeat(tests: Array, repeat: int) -> Array:
 func _setup_editor_assets(assets_registry):
 	Summary._setup_editor_assets(assets_registry)
 	Menu._setup_editor_assets(assets_registry)
+	Results._setup_editor_assets(assets_registry)

--- a/addons/WAT/ui/scripts/core.gd
+++ b/addons/WAT/ui/scripts/core.gd
@@ -6,6 +6,9 @@ onready var Results: TabContainer = $Results
 onready var ViewMenu: PopupMenu = $Menu/ResultsMenu.get_popup()
 onready var RunSettings: HBoxContainer = $Menu/RunSettings
 onready var RunMenu: Button = $Menu/TestMenu
+onready var Summary: HBoxContainer = $Summary
+onready var Menu: Control = $Menu
+
 signal test_strategy_set
 
 func _ready() -> void:
@@ -30,3 +33,8 @@ func _repeat(tests: Array, repeat: int) -> Array:
 			duplicates.append(test)
 	duplicates += tests
 	return duplicates
+
+# Loads scaled assets like icons and fonts
+func _setup_editor_assets(assets_registry):
+	Summary._setup_editor_assets(assets_registry)
+	Menu._setup_editor_assets(assets_registry)

--- a/addons/WAT/ui/scripts/gui.gd
+++ b/addons/WAT/ui/scripts/gui.gd
@@ -11,6 +11,7 @@ const XML: Script = preload("res://addons/WAT/editor/junit_xml.gd")
 onready var TestMenu: Button = $Core/Menu/TestMenu
 onready var Results: TabContainer = $Core/Results
 onready var Summary: HBoxContainer = $Core/Summary
+onready var Core: VBoxContainer = $Core
 var instance: TestRunner
 var server: Server
 signal launched_via_editor
@@ -67,3 +68,7 @@ func _exit_tree() -> void:
 
 func _set_window_size() -> void:
 	OS.window_size = ProjectSettings.get_setting("WAT/Window_Size")
+
+# Loads scaled assets like icons and fonts
+func _setup_editor_assets(assets_registry):
+	Core._setup_editor_assets(assets_registry)

--- a/addons/WAT/ui/scripts/menu.gd
+++ b/addons/WAT/ui/scripts/menu.gd
@@ -1,0 +1,8 @@
+extends Control
+tool
+
+onready var QuickRunAll: Button = $QuickRunAll
+
+# Loads scaled assets like icons and fonts
+func _setup_editor_assets(assets_registry):
+	QuickRunAll.icon = assets_registry.load_asset(QuickRunAll.icon)

--- a/addons/WAT/ui/scripts/plugin_assets_registry.gd
+++ b/addons/WAT/ui/scripts/plugin_assets_registry.gd
@@ -1,0 +1,52 @@
+# Repo: https://github.com/Atlinx/Godot-PluginAssetsRegistry
+
+extends Reference
+
+# Replace 'demo_plugin' with your plugin's name
+const PLUGIN_ABSOLUTE_PATH_PREFIX = "res://addons/WAT/"
+
+var plugin: EditorPlugin
+
+# Stores already loaded assets so multiple loads of the same asset 
+# do not duplicate the same asset multiple times.  
+var loaded_editor_assets: Dictionary
+
+func _init(plugin_: EditorPlugin):
+	plugin = plugin_
+
+# Returns an asset scaled to fit the current editor's UI scale
+# Can load scaled asset with a string using the plugin folder as the root older
+# Can load scaled asset using an already loaded asset 
+func load_asset(asset):
+	if asset is String:
+		return load_asset(load(PLUGIN_ABSOLUTE_PATH_PREFIX + asset))
+	else:
+		# Godot compares by reference by default for dictionaries that use objects as keys
+		if loaded_editor_assets.has(asset):
+			return loaded_editor_assets[asset]
+		else:
+			if asset is Font:
+				loaded_editor_assets[asset] = _load_scaled_font(asset)
+				return loaded_editor_assets[asset]
+			elif asset is Texture:
+				loaded_editor_assets[asset] = _load_scaled_texture(asset)
+				return loaded_editor_assets[asset]
+			assert(false, "Cannot scale asset of type " + asset.get_class())
+
+func _load_scaled_texture(texture: Texture) -> Texture:
+	# get_data already returns a copy, therefore no need to duplicate
+	var image = texture.get_data()
+	image.resize(image.get_width() * get_editor_scale(), image.get_height() * get_editor_scale())
+	
+	var scaled_texture = ImageTexture.new()
+	scaled_texture.create_from_image(image)
+	
+	return scaled_texture 
+
+func _load_scaled_font(font: Font) -> DynamicFont:
+	var duplicate = font.duplicate()
+	duplicate.size *= get_editor_scale()
+	return duplicate
+	
+func get_editor_scale():
+	return plugin.get_editor_interface().get_editor_scale()

--- a/addons/WAT/ui/scripts/result_forest.gd
+++ b/addons/WAT/ui/scripts/result_forest.gd
@@ -1,11 +1,13 @@
 extends TabContainer
 tool
 
-const PASSED_ICON: Texture = preload("res://addons/WAT/assets/passed.png")
-const FAILED_ICON: Texture = preload("res://addons/WAT/assets/failed.png")
+var PASSED_ICON: Texture
+var FAILED_ICON: Texture
 const ResultTree = preload("res://addons/WAT/ui/scripts/result_tree.gd")
 var _results: Array
 var _tabs = {}
+# Stores asset_registry so that result_tree can be configured with scaled icons
+var _assets_registry
 signal function_selected
 
 func display(results: Array) -> void:
@@ -19,6 +21,7 @@ func _add_result_tree(results: Array) -> void:
 	var sorted = sort(results)
 	for path in sorted:
 		var result_tree = ResultTree.new()
+		result_tree._setup_editor_assets(_assets_registry)
 		result_tree.connect("function_selected", self, "_on_function_selected")
 		result_tree.connect("calculated", self, "_on_tree_results_calculated")
 		result_tree.name = path
@@ -89,3 +92,10 @@ func collapse_all():
 func expand_failures():
 	for results in get_children():
 		results.expand_failures()
+
+# Loads scaled assets like icons and fonts
+func _setup_editor_assets(assets_registry):
+	_assets_registry = assets_registry
+	PASSED_ICON = assets_registry.load_asset("assets/passed.png")
+	FAILED_ICON = assets_registry.load_asset("assets/failed.png")
+

--- a/addons/WAT/ui/scripts/result_tree.gd
+++ b/addons/WAT/ui/scripts/result_tree.gd
@@ -1,9 +1,9 @@
 extends Tree
 tool
 
-const FUNCTION: Texture = preload("res://addons/WAT/assets/function.png")
-const PASSED_ICON: Texture = preload("res://addons/WAT/assets/passed.png")
-const FAILED_ICON: Texture = preload("res://addons/WAT/assets/failed.png")
+var FUNCTION: Texture
+var PASSED_ICON: Texture
+var FAILED_ICON: Texture
 const PASSED: Color = Color(0, 1, 0, 1)
 const FAILED: Color = Color(1, 1, 1, 1)
 signal calculated
@@ -92,3 +92,10 @@ func collapse_all() -> void:
 func expand_failures() -> void:
 	for item in _mega_cache:
 		item.collapsed = true if item.get_icon(0) == PASSED_ICON else false
+
+# Loads scaled assets like icons and fonts
+func _setup_editor_assets(assets_registry):
+	FUNCTION = assets_registry.load_asset("assets/function.png")
+	PASSED_ICON = assets_registry.load_asset("assets/passed.png")
+	FAILED_ICON = assets_registry.load_asset("assets/failed.png")
+

--- a/addons/WAT/ui/scripts/summary.gd
+++ b/addons/WAT/ui/scripts/summary.gd
@@ -37,3 +37,11 @@ func summarize(caselist: Array) -> void:
 	Passing.text = passed as String
 	Failing.text = failed as String
 	Runs.text = runcount as String
+
+# Loads scaled assets like icons and fonts
+func _setup_editor_assets(assets_registry):
+	Time.icon = assets_registry.load_asset(Time.icon)
+	Tests.icon = assets_registry.load_asset(Tests.icon)
+	Passing.icon = assets_registry.load_asset(Passing.icon)
+	Failing.icon = assets_registry.load_asset(Failing.icon)
+	Runs.icon = assets_registry.load_asset(Runs.icon)

--- a/tests/results/WAT/results.xml
+++ b/tests/results/WAT/results.xml
@@ -1,23 +1,20 @@
 <?xml version="1.0" ?>
 <testsuites failures="0" name="TestXML" tests="15" time="0">
-	<testsuite name="NameSpaced" failures="0"  tests="1" time="0">
-		<testcase name="x" time="0"></testcase>
-	</testsuite>
-
-	<testsuite name="Given The Addition Operator (Parameter Tests)" failures="0"  tests="3" time="0">
-		<testcase name="When we add 2 to 2 we get 4" time="0"></testcase>
-		<testcase name="When we add 5 to 3 we get 8" time="0"></testcase>
-		<testcase name="When we add 7 to 6 we get 13" time="0"></testcase>
-	</testsuite>
-
 	<testsuite name="BasicCSharpTest" failures="0"  tests="2" time="0">
 		<testcase name="CSharpTestsWorking" time="0"></testcase>
 		<testcase name="CSXharpTestsWorking" time="0"></testcase>
 	</testsuite>
 
-	<testsuite name="Range Assertions" failures="0"  tests="2" time="0">
-		<testcase name="WhenCallingIsInRange" time="0"></testcase>
-		<testcase name="WhenCallingIsNotInRange" time="0"></testcase>
+	<testsuite name="Given A Boolean Assertion" failures="0"  tests="2" time="0">
+		<testcase name="TrueIsTrue" time="0"></testcase>
+		<testcase name="FalseIsFalse" time="0"></testcase>
+	</testsuite>
+
+	<testsuite name="Given A Boolean Assertion (GDScript WATTest)" failures="0"  tests="4" time="0">
+		<testcase name="True is true" time="0"></testcase>
+		<testcase name=" Value is true" time="0"></testcase>
+		<testcase name=" Value is true" time="0"></testcase>
+		<testcase name=" False is false" time="0"></testcase>
 	</testsuite>
 
 	<testsuite name="Given an Equality Assertion" failures="0"  tests="7" time="0">
@@ -30,44 +27,10 @@
 		<testcase name="WhenCallingIsNotEqual" time="0"></testcase>
 	</testsuite>
 
-	<testsuite name="Given A Signal Watcher" failures="0"  tests="4" time="0">
-		<testcase name="WhenWeWatchASignalFromAnObjectWithNoBoundVariables" time="0"></testcase>
-		<testcase name="When we watch and emit a signal" time="0"></testcase>
-		<testcase name="When we Watch and Do not Emit a Signal" time="0"></testcase>
-		<testcase name="WhenWeWatchASignalAndEmitItMultipleTimes" time="0"></testcase>
-	</testsuite>
-
-	<testsuite name="Given A Boolean Assertion (GDScript WATTest)" failures="0"  tests="4" time="0">
-		<testcase name=" False is false" time="0"></testcase>
-		<testcase name="True is true" time="0"></testcase>
-		<testcase name=" Value is true" time="0"></testcase>
-		<testcase name=" Value is true" time="0"></testcase>
-	</testsuite>
-
-	<testsuite name="Given A String Assertion" failures="0"  tests="6" time="0">
-		<testcase name="WhenCallingStringBeginWith" time="0"></testcase>
-		<testcase name="WhenCallingStringDoesNotBeginWith" time="0"></testcase>
-		<testcase name="WhenCallingStringContains" time="0"></testcase>
-		<testcase name="WhenCallingStringDoesNotContain" time="0"></testcase>
-		<testcase name="WhenCallingStringEndsWith" time="0"></testcase>
-		<testcase name="WhenCallingStringDoesNotEndWith" time="0"></testcase>
-	</testsuite>
-
-	<testsuite name="Object Assertions" failures="0"  tests="14" time="0">
-		<testcase name="WhenCallingHasMetaAfterAddingMetadata" time="0"></testcase>
-		<testcase name="WhenCallingDoesNotHaveMeta" time="0"></testcase>
-		<testcase name="WhenCallingDoesNotHaveMetalRealKeyButNullValue" time="0"></testcase>
-		<testcase name="WhenCallingHasMethodTitle" time="0"></testcase>
-		<testcase name="WhenCallingDoesNotHaveMethodFalseMethod" time="0"></testcase>
-		<testcase name="WhenCallingHasUserSignalAfterAddingASignal" time="0"></testcase>
-		<testcase name="WhenCallingDoesNotHaveUserSignal" time="0"></testcase>
-		<testcase name="WhenCallingDoesNotHaveUserSignalWithClassSignalConstant" time="0"></testcase>
-		<testcase name="WhenCallingObjectIsQueuedForDeletionAfterCallingQueueFree" time="0"></testcase>
-		<testcase name="WhenCallingObjectIsNotQueuedForDeletionAfterNotCallingQueueFree" time="0"></testcase>
-		<testcase name="WhenCallingObjIsConnectedWithARealConnection" time="0"></testcase>
-		<testcase name="WhenCallingObjIsNotConnectedWithAnInvalidConnection" time="0"></testcase>
-		<testcase name="TestIsBlockingSignals" time="0"></testcase>
-		<testcase name="IsNotBlockingSignals" time="0"></testcase>
+	<testsuite name="FileTest" failures="0"  tests="3" time="0">
+		<testcase name="ThisFileExists" time="0"></testcase>
+		<testcase name="ImaginaryFileDoesNotExist" time="0"></testcase>
+		<testcase name="EmptyPathDoesNotExist" time="0"></testcase>
 	</testsuite>
 
 	<testsuite name="Is Instance ( class / type ) Assertions" failures="0"  tests="19" time="0">
@@ -114,9 +77,36 @@
 		<testcase name="IsNotVector3" time="0"></testcase>
 	</testsuite>
 
-	<testsuite name="Given A Boolean Assertion" failures="0"  tests="2" time="0">
-		<testcase name="TrueIsTrue" time="0"></testcase>
-		<testcase name="FalseIsFalse" time="0"></testcase>
+	<testsuite name="NameSpaced" failures="0"  tests="1" time="0">
+		<testcase name="x" time="0"></testcase>
+	</testsuite>
+
+	<testsuite name="Object Assertions" failures="0"  tests="14" time="0">
+		<testcase name="WhenCallingHasMetaAfterAddingMetadata" time="0"></testcase>
+		<testcase name="WhenCallingDoesNotHaveMeta" time="0"></testcase>
+		<testcase name="WhenCallingDoesNotHaveMetalRealKeyButNullValue" time="0"></testcase>
+		<testcase name="WhenCallingHasMethodTitle" time="0"></testcase>
+		<testcase name="WhenCallingDoesNotHaveMethodFalseMethod" time="0"></testcase>
+		<testcase name="WhenCallingHasUserSignalAfterAddingASignal" time="0"></testcase>
+		<testcase name="WhenCallingDoesNotHaveUserSignal" time="0"></testcase>
+		<testcase name="WhenCallingDoesNotHaveUserSignalWithClassSignalConstant" time="0"></testcase>
+		<testcase name="WhenCallingObjectIsQueuedForDeletionAfterCallingQueueFree" time="0"></testcase>
+		<testcase name="WhenCallingObjectIsNotQueuedForDeletionAfterNotCallingQueueFree" time="0"></testcase>
+		<testcase name="WhenCallingObjIsConnectedWithARealConnection" time="0"></testcase>
+		<testcase name="WhenCallingObjIsNotConnectedWithAnInvalidConnection" time="0"></testcase>
+		<testcase name="TestIsBlockingSignals" time="0"></testcase>
+		<testcase name="IsNotBlockingSignals" time="0"></testcase>
+	</testsuite>
+
+	<testsuite name="Given The Addition Operator (Parameter Tests)" failures="0"  tests="3" time="0">
+		<testcase name="When we add 2 to 2 we get 4" time="0"></testcase>
+		<testcase name="When we add 5 to 3 we get 8" time="0"></testcase>
+		<testcase name="When we add 7 to 6 we get 13" time="0"></testcase>
+	</testsuite>
+
+	<testsuite name="Range Assertions" failures="0"  tests="2" time="0">
+		<testcase name="WhenCallingIsInRange" time="0"></testcase>
+		<testcase name="WhenCallingIsNotInRange" time="0"></testcase>
 	</testsuite>
 
 	<testsuite name="Recorder Test" failures="0"  tests="2" time="0">
@@ -124,10 +114,20 @@
 		<testcase name="WhenAHeroIsPoisonedTheirHealthIs0After100Cycles" time="0"></testcase>
 	</testsuite>
 
-	<testsuite name="FileTest" failures="0"  tests="3" time="0">
-		<testcase name="ThisFileExists" time="0"></testcase>
-		<testcase name="ImaginaryFileDoesNotExist" time="0"></testcase>
-		<testcase name="EmptyPathDoesNotExist" time="0"></testcase>
+	<testsuite name="Given A String Assertion" failures="0"  tests="6" time="0">
+		<testcase name="WhenCallingStringBeginWith" time="0"></testcase>
+		<testcase name="WhenCallingStringDoesNotBeginWith" time="0"></testcase>
+		<testcase name="WhenCallingStringContains" time="0"></testcase>
+		<testcase name="WhenCallingStringDoesNotContain" time="0"></testcase>
+		<testcase name="WhenCallingStringEndsWith" time="0"></testcase>
+		<testcase name="WhenCallingStringDoesNotEndWith" time="0"></testcase>
+	</testsuite>
+
+	<testsuite name="Given A Signal Watcher" failures="0"  tests="4" time="0">
+		<testcase name="WhenWeWatchASignalFromAnObjectWithNoBoundVariables" time="0"></testcase>
+		<testcase name="When we watch and emit a signal" time="0"></testcase>
+		<testcase name="When we Watch and Do not Emit a Signal" time="0"></testcase>
+		<testcase name="WhenWeWatchASignalAndEmitItMultipleTimes" time="0"></testcase>
 	</testsuite>
 
 	<testsuite name="Given a Yield" failures="0"  tests="10" time="0">


### PR DESCRIPTION
I've incorporated my [PluginAssetsRegistry](https://github.com/Atlinx/Godot-PluginAssetsRegistry) into this plugin to dynamically scale the plugin icons depending on the user's editor UI scale. This makes plugin icons visible on HIDPI displays.

Below are some images depicting the changes:

Before:
![BeforeIconRescalingPNG](https://user-images.githubusercontent.com/25368491/117520010-2d89ba00-af74-11eb-8dd7-22dfffcd3188.PNG)

After:
![AfterIconRescalingWithRuns](https://user-images.githubusercontent.com/25368491/117520015-32e70480-af74-11eb-8d37-833d4634d34c.PNG)

This change can also be ported to the GDScript repo as well if approved as PluginAssetsRegistry is completely written in GDScript.  