### PR TITLE
Support long unit tests

### DIFF
--- a/addons/WAT/network/server.gd
+++ b/addons/WAT/network/server.gd
@@ -24,6 +24,7 @@ func host() -> void:
 	
 func _on_peer_connected(id: int) -> void:
 	rpc_id(id, "test_strategy_received", tests, threads)
+	_server.set_peer_timeout(id, 59000, 60000, 61000)
 
 master func _on_run_completed(results: Array) -> void:
 	rpc_id(multiplayer.get_rpc_sender_id(), "run_completion_confirmed")

--- a/addons/WAT/network/server.gd
+++ b/addons/WAT/network/server.gd
@@ -7,6 +7,7 @@ extends "custom_networking.gd"
 var _server: NetworkedMultiplayerENet
 var tests: Array = []
 var threads: int = 1
+var awaiting_results: bool = false
 signal run_completed
 
 func _ready() -> void:
@@ -21,12 +22,19 @@ func host() -> void:
 		push_warning(err as String)
 	custom_multiplayer.network_peer = _server
 	custom_multiplayer.connect("network_peer_connected", self, "_on_peer_connected")
+	custom_multiplayer.connect("network_peer_disconnected", self, "_on_peer_disconnected")
 	
 func _on_peer_connected(id: int) -> void:
 	rpc_id(id, "test_strategy_received", tests, threads)
 	_server.set_peer_timeout(id, 59000, 60000, 61000)
+	awaiting_results = true
+	
+func _on_peer_disconnected(id: int) -> void:
+	if (awaiting_results):
+		push_warning("WAT: Peer disconnected early. Check connection or timeout settings in WAT server.gd (60s default)")
 
 master func _on_run_completed(results: Array) -> void:
+	awaiting_results = false
 	rpc_id(multiplayer.get_rpc_sender_id(), "run_completion_confirmed")
 	emit_signal("run_completed", results)
 	


### PR DESCRIPTION
Per default, the server disconnects very quickly if the client is not responding. If a unit test takes some seconds, the server immediately disconnects without a warning.
I run into this problem when I wrote integration tests that can take several seconds like loading and saving games, especially on a server with limited resources.

- Added warning if a client disconnects or was disconnected without an answer
- Increased timeout to ~1 minute

Possible improvements: Set custom timeout in the WAT editor settings page